### PR TITLE
[bugfix] NAT IPv6 lookup bugfix

### DIFF
--- a/src/common/network/ipv6_utils.h
+++ b/src/common/network/ipv6_utils.h
@@ -30,14 +30,27 @@ inline boost::multiprecision::uint128_t toUInt128(
 inline std::string toString(const boost::multiprecision::uint128_t& val) {
   const std::uint64_t high = static_cast<uint64_t>(val >> 64);  // High 64 bits
   const std::uint64_t low =
-      static_cast<uint64_t>(val & 0xFFFFFFFFFFFFFFFF);  // Low 64 bits
-  std::stringstream ss;
-  ss << std::hex << std::setw(4) << std::setfill('0') << (high >> 48) << ':'
-     << std::setw(4) << (high >> 32 & 0xFFFF) << ':' << std::setw(4)
-     << (high >> 16 & 0xFFFF) << ':' << std::setw(4) << (high & 0xFFFF) << ':'
-     << std::setw(4) << (low >> 48) << ':' << std::setw(4)
-     << (low >> 32 & 0xFFFF) << ':' << std::setw(4) << (low >> 16 & 0xFFFF)
-     << ':' << std::setw(4) << (low & 0xFFFF);
-  return ss.str();
+      static_cast<uint64_t>(val & 0xFFFFFFFFFFFFFFFF);
+  // Build 16-byte network-order address from the two 64-bit halves
+  const boost::asio::ip::address_v6::bytes_type bytes = {{
+      static_cast<unsigned char>(high >> 56),
+      static_cast<unsigned char>(high >> 48),
+      static_cast<unsigned char>(high >> 40),
+      static_cast<unsigned char>(high >> 32),
+      static_cast<unsigned char>(high >> 24),
+      static_cast<unsigned char>(high >> 16),
+      static_cast<unsigned char>(high >> 8),
+      static_cast<unsigned char>(high),
+      static_cast<unsigned char>(low >> 56),
+      static_cast<unsigned char>(low >> 48),
+      static_cast<unsigned char>(low >> 40),
+      static_cast<unsigned char>(low >> 32),
+      static_cast<unsigned char>(low >> 24),
+      static_cast<unsigned char>(low >> 16),
+      static_cast<unsigned char>(low >> 8),
+      static_cast<unsigned char>(low),
+  }};
+  // Produces canonical compressed format (matches pcpp/inet_ntop)
+  return boost::asio::ip::make_address_v6(bytes).to_string();
 }
 }  // namespace fptn::common::network::ipv6

--- a/tests/common/CMakeLists.txt
+++ b/tests/common/CMakeLists.txt
@@ -45,3 +45,8 @@ add_test(NAME IPv4GeneratorTest COMMAND IPv4GeneratorTest)
 add_executable(IPv6GeneratorTest network/IPv6GeneratorTest.cpp)
 target_link_libraries(IPv6GeneratorTest PRIVATE ${LIBS})
 add_test(NAME IPv6GeneratorTest COMMAND IPv6GeneratorTest)
+
+# --- IPv6 Utils test ---
+add_executable(IPv6UtilsTest network/IPv6UtilsTest.cpp)
+target_link_libraries(IPv6UtilsTest PRIVATE ${LIBS})
+add_test(NAME IPv6UtilsTest COMMAND IPv6UtilsTest)

--- a/tests/common/network/IPv6GeneratorTest.cpp
+++ b/tests/common/network/IPv6GeneratorTest.cpp
@@ -4,6 +4,8 @@ Copyright (c) 2024-2025 Stas Skokov
 Distributed under the MIT License (https://opensource.org/licenses/MIT)
 =============================================================================*/
 
+#include <string>
+
 #include <fmt/core.h>  // NOLINT(build/include_order)
 
 #include <gtest/gtest.h>  // NOLINT(build/include_order)

--- a/tests/common/network/IPv6GeneratorTest.cpp
+++ b/tests/common/network/IPv6GeneratorTest.cpp
@@ -8,7 +8,15 @@ Distributed under the MIT License (https://opensource.org/licenses/MIT)
 
 #include <gtest/gtest.h>  // NOLINT(build/include_order)
 
+#include <boost/asio/ip/address_v6.hpp>
+
 #include "common/network/ipv6_generator.h"
+
+// Helper: produce the canonical compressed IPv6 string for a given
+// full-hex address, so test expectations match inet_ntop / pcpp output.
+static std::string canonical(const std::string& full_hex) {
+  return boost::asio::ip::make_address_v6(full_hex).to_string();
+}
 
 TEST(IPv6GeneratorTest, InitialAddress) {
   fptn::common::network::IPv6AddressGenerator generator(
@@ -18,13 +26,16 @@ TEST(IPv6GeneratorTest, InitialAddress) {
   EXPECT_EQ(generator.NumAvailableAddresses(), 254);
 
   const auto address1 = generator.GetNextAddress();
-  EXPECT_EQ(address1.ToString(), "2001:0db8:0000:0000:0000:0000:0000:0001");
+  EXPECT_EQ(address1.ToString(),
+      canonical("2001:0db8:0000:0000:0000:0000:0000:0001"));
 
   const auto address2 = generator.GetNextAddress();
-  EXPECT_EQ(address2.ToString(), "2001:0db8:0000:0000:0000:0000:0000:0002");
+  EXPECT_EQ(address2.ToString(),
+      canonical("2001:0db8:0000:0000:0000:0000:0000:0002"));
 
   const auto address3 = generator.GetNextAddress();
-  EXPECT_EQ(address3.ToString(), "2001:0db8:0000:0000:0000:0000:0000:0003");
+  EXPECT_EQ(address3.ToString(),
+      canonical("2001:0db8:0000:0000:0000:0000:0000:0003"));
 }
 
 TEST(IPv6GeneratorTest, NumAvaliableAddresses) {
@@ -37,12 +48,14 @@ TEST(IPv6GeneratorTest, NumAvaliableAddresses) {
   for (int i = 1; i <= 254; i++) {
     const auto address = generator.GetNextAddress();
     EXPECT_EQ(address.ToString(),
-        fmt::format("2001:0db8:0001:0000:0000:0000:0000:{:04x}", i));
+        canonical(
+            fmt::format("2001:0db8:0001:0000:0000:0000:0000:{:04x}", i)));
   }
 
   {  // Repeat test
     const auto address = generator.GetNextAddress();
-    EXPECT_EQ(address.ToString(), "2001:0db8:0001:0000:0000:0000:0000:0001");
+    EXPECT_EQ(address.ToString(),
+        canonical("2001:0db8:0001:0000:0000:0000:0000:0001"));
   }
 }
 
@@ -56,7 +69,8 @@ TEST(IPv6GeneratorTest, SmallDifficultNetsMask) {
   for (int i = 1; i <= 14; i++) {
     const auto address = generator.GetNextAddress();
     EXPECT_EQ(address.ToString(),
-        fmt::format("2001:0db8:0002:0000:0000:0000:0000:{:04x}", i));
+        canonical(
+            fmt::format("2001:0db8:0002:0000:0000:0000:0000:{:04x}", i)));
   }
 }
 
@@ -75,8 +89,9 @@ TEST(IPv6GeneratorTest, BigDifficultNetsMask) {
       }
       const auto address = generator.GetNextAddress();
       EXPECT_EQ(address.ToString(),
-          fmt::format("2001:0db8:0003:0000:0000:0000:{:02x}{:02x}:{:02x}{:02x}",
-              0, 0, i, j));
+          canonical(fmt::format(
+              "2001:0db8:0003:0000:0000:0000:{:02x}{:02x}:{:02x}{:02x}", 0, 0,
+              i, j)));
       counter += 1;
     }
   }

--- a/tests/common/network/IPv6GeneratorTest.cpp
+++ b/tests/common/network/IPv6GeneratorTest.cpp
@@ -14,11 +14,13 @@ Distributed under the MIT License (https://opensource.org/licenses/MIT)
 
 #include "common/network/ipv6_generator.h"
 
+namespace {
 // Helper: produce the canonical compressed IPv6 string for a given
 // full-hex address, so test expectations match inet_ntop / pcpp output.
-static std::string canonical(const std::string& full_hex) {
+std::string canonical(const std::string& full_hex) {
   return boost::asio::ip::make_address_v6(full_hex).to_string();
 }
+}  // namespace
 
 TEST(IPv6GeneratorTest, InitialAddress) {
   fptn::common::network::IPv6AddressGenerator generator(

--- a/tests/common/network/IPv6UtilsTest.cpp
+++ b/tests/common/network/IPv6UtilsTest.cpp
@@ -4,6 +4,9 @@ Copyright (c) 2024-2026 Pavel Shpilev
 Distributed under the MIT License (https://opensource.org/licenses/MIT)
 =============================================================================*/
 
+#include <string>
+#include <vector>
+
 #include <gtest/gtest.h>  // NOLINT(build/include_order)
 
 #include <pcapplusplus/IPv6Layer.h>  // NOLINT(build/include_order)

--- a/tests/common/network/IPv6UtilsTest.cpp
+++ b/tests/common/network/IPv6UtilsTest.cpp
@@ -52,7 +52,7 @@ TEST(IPv6UtilsTest, ServerDefaultSubnetMatchesPcpp) {
   // Generate a few addresses and verify they match pcpp's format
   for (int i = 1; i <= 5; i++) {
     const auto generated = generator.GetNextAddress();
-    const std::string gen_str = generated.ToString();
+    const auto& gen_str = generated.ToString();
 
     // Round-trip through pcpp (simulates what happens on packet receive)
     const pcpp::IPv6Address pcpp_addr(gen_str);

--- a/tests/common/network/IPv6UtilsTest.cpp
+++ b/tests/common/network/IPv6UtilsTest.cpp
@@ -1,0 +1,90 @@
+/*=============================================================================
+Copyright (c) 2024-2026 Pavel Shpilev
+
+Distributed under the MIT License (https://opensource.org/licenses/MIT)
+=============================================================================*/
+
+#include <gtest/gtest.h>  // NOLINT(build/include_order)
+
+#include <pcapplusplus/IPv6Layer.h>  // NOLINT(build/include_order)
+
+#include "common/network/ipv6_generator.h"
+#include "common/network/ipv6_utils.h"
+
+// This test demonstrates that the IPv6 string representation from the
+// generator must match the format produced by pcpp::IPv6Address::toString(),
+// because the server NAT table uses these strings as map keys.
+// If the formats differ, the NAT lookup fails and IPv6 response packets
+// are silently dropped.
+TEST(IPv6UtilsTest, ToStringMatchesPcppFormat) {
+  // Simulate what the IPv6 generator does: convert an address to uint128,
+  // then back to string using ipv6::toString()
+  const std::string original = "fc00:1::2";
+  const auto boost_addr = boost::asio::ip::make_address_v6(original);
+  const auto uint128_val = fptn::common::network::ipv6::toUInt128(boost_addr);
+  const std::string generator_str =
+      fptn::common::network::ipv6::toString(uint128_val);
+
+  // Simulate what happens when a response packet arrives: pcpp extracts
+  // the IPv6 address and we call toString() on it
+  const pcpp::IPv6Address pcpp_addr(original);
+  const std::string pcpp_str = pcpp_addr.toString();
+
+  // These MUST match, otherwise the NAT table lookup will fail
+  EXPECT_EQ(generator_str, pcpp_str)
+      << "IPv6 string format mismatch between generator ('" << generator_str
+      << "') and pcpp ('" << pcpp_str
+      << "'). This causes NAT table lookups to fail, "
+         "dropping all IPv6 response packets.";
+}
+
+// Test with the actual server default subnet
+TEST(IPv6UtilsTest, ServerDefaultSubnetMatchesPcpp) {
+  // Server defaults from CMakeLists.txt:
+  //   FPTN_SERVER_DEFAULT_NET_ADDRESS_IP6="fc00:1::"
+  //   Mask: /112
+  fptn::common::network::IPv6AddressGenerator generator(
+      fptn::common::network::IPv6Address("fc00:1::"), 112);
+
+  // Generate a few addresses and verify they match pcpp's format
+  for (int i = 1; i <= 5; i++) {
+    const auto generated = generator.GetNextAddress();
+    const std::string gen_str = generated.ToString();
+
+    // Round-trip through pcpp (simulates what happens on packet receive)
+    const pcpp::IPv6Address pcpp_addr(gen_str);
+    const std::string pcpp_str = pcpp_addr.toString();
+
+    EXPECT_EQ(gen_str, pcpp_str)
+        << "Mismatch for generated address #" << i << ": generator='"
+        << gen_str << "' vs pcpp='" << pcpp_str << "'";
+  }
+}
+
+// Test with various address patterns that exercise zero-compression
+TEST(IPv6UtilsTest, ToStringFormatsMatchPcppForVariousAddresses) {
+  const std::vector<std::string> test_addresses = {
+      "::1",
+      "fe80::1",
+      "2001:db8::1",
+      "fc00:1::2",
+      "2001:db8:85a3::8a2e:370:7334",
+      "ff02::1",
+      "::",
+  };
+
+  for (const auto& addr_str : test_addresses) {
+    const auto boost_addr = boost::asio::ip::make_address_v6(addr_str);
+    const auto uint128_val =
+        fptn::common::network::ipv6::toUInt128(boost_addr);
+    const std::string utils_str =
+        fptn::common::network::ipv6::toString(uint128_val);
+
+    const pcpp::IPv6Address pcpp_addr(addr_str);
+    const std::string pcpp_str = pcpp_addr.toString();
+
+    EXPECT_EQ(utils_str, pcpp_str)
+        << "Format mismatch for input '" << addr_str << "': utils='"
+        << utils_str << "' vs pcpp='" << pcpp_str << "'";
+  }
+}


### PR DESCRIPTION
Fixing a bug where the NAT table stored IPv6 keys in fully-expanded hex but looked up using the compressed canonical form