### PR TITLE
[bugfix] reconnect: fix zombie VPN when TUN fails to reopen

### DIFF
--- a/src/common/network/tun/win_tun_device.h
+++ b/src/common/network/tun/win_tun_device.h
@@ -35,15 +35,22 @@ class WinTunDevice {
         session_(nullptr),
         running_(nullptr) {
     wintun_ = InitializeWintun();
-    UuidCreate(&guid_);
   }
 
-  ~WinTunDevice() { Close(); }
+  ~WinTunDevice() {
+    Close();
+    if (wintun_) {
+      WintunDeleteDriver();
+      wintun_ = nullptr;
+    }
+  }
 
   WinTunDevice(const WinTunDevice&) = delete;
   WinTunDevice& operator=(const WinTunDevice&) = delete;
 
   bool Open(const std::string& name) {
+    UuidCreate(&guid_);
+
     if (!wintun_) {
       return false;
     }
@@ -69,10 +76,6 @@ class WinTunDevice {
     if (adapter_) {
       WintunCloseAdapter(adapter_);
       adapter_ = nullptr;
-    }
-    if (wintun_) {
-      WintunDeleteDriver();
-      wintun_ = nullptr;
     }
   }
 

--- a/src/fptn-client/vpn/http/client.cpp
+++ b/src/fptn-client/vpn/http/client.cpp
@@ -6,8 +6,10 @@ Distributed under the MIT License (https://opensource.org/licenses/MIT)
 
 #include "vpn/http/client.h"
 
+#include <chrono>
 #include <memory>
 #include <string>
+#include <thread>
 #include <utility>
 
 #include <boost/process/v1/io.hpp>
@@ -30,12 +32,20 @@ using fptn::vpn::http::Client;
 Client::Client(fptn::protocol::https::WebsocketClient::Config config)
     : running_(false),
       reconnection_attempts_(kMaxReconnectionAttempts_),
-      config_(std::move(config)) {}
+      config_(std::move(config)) {
+  config_.access_token = "";
+}
 
-Client::~Client() { Stop(); }
+Client::~Client() {
+  Stop();
+}
 
 bool Client::Login(
     const std::string& username, const std::string& password, int timeout_sec) {
+  if (!config_.access_token.empty()) {
+    return true;
+  }
+
   const std::string request = fmt::format(
       R"({{ "username": "{}", "password": "{}" }})", username, password);
 
@@ -43,31 +53,46 @@ bool Client::Login(
   ApiClient cli(ip, config_.server_port, config_.sni,
       config_.expected_md5_fingerprint, config_.censorship_strategy);
 
-  const auto resp = cli.Post(
-      common::api::kApiLoginUrl, request, "application/json", timeout_sec);
-  if (resp.code == 200) {
-    try {
-      const auto msg = resp.Json();
-      if (!msg.contains("access_token")) {
-        SPDLOG_ERROR(
-            "Error: Access token not found in the response. Check your "
-            "conection");
-      } else {
-        config_.access_token = msg["access_token"];
-        SPDLOG_INFO("Login successful");
-        return true;
-      }
-    } catch (const nlohmann::json::parse_error& e) {
-      latest_error_ = e.what();
-      SPDLOG_ERROR("Error parsing JSON response: {} ", e.what());
-    } catch (const std::exception& ex) {
-      latest_error_ = ex.what();
-      SPDLOG_ERROR("Exception: {}", ex.what());
+  constexpr int kMaxRetries = 3;
+  for (int attempt = 0; attempt < kMaxRetries; ++attempt) {
+    if (attempt > 0) {
+      SPDLOG_WARN("Login retry attempt {}/{}", attempt, kMaxRetries);
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
-  } else {
-    latest_error_ = resp.errmsg;
-    SPDLOG_ERROR(
-        "Error: Request failed code: {} msg: {}", resp.code, resp.errmsg);
+    const auto resp = cli.Post(
+        common::api::kApiLoginUrl, request, "application/json", timeout_sec);
+    if (resp.code == 200) {
+      try {
+        const auto msg = resp.Json();
+        if (!msg.contains("access_token")) {
+          SPDLOG_ERROR(
+              "Error: Access token not found in the response. Check your "
+              "conection");
+        } else {
+          config_.access_token = msg["access_token"];
+          SPDLOG_INFO("Login successful");
+          return true;
+        }
+      } catch (const nlohmann::json::parse_error& e) {
+        config_.access_token = "";
+        latest_error_ = e.what();
+        SPDLOG_ERROR("Error parsing JSON response: {} ", e.what());
+      } catch (const std::exception& ex) {
+        config_.access_token = "";
+        latest_error_ = ex.what();
+        SPDLOG_ERROR("Exception: {}", ex.what());
+      }
+    } else if (resp.code == 401 || resp.code == 403) {
+      config_.access_token = "";
+      latest_error_ = resp.errmsg;
+      SPDLOG_ERROR("Auth error ({}): wrong username or password", resp.code);
+      return false;
+    } else {
+      config_.access_token = "";
+      latest_error_ = resp.errmsg;
+      SPDLOG_ERROR(
+          "Error: Request failed code: {} msg: {}", resp.code, resp.errmsg);
+    }
   }
   return false;
 }
@@ -76,37 +101,50 @@ std::pair<IPv4Address, IPv6Address> Client::GetDns() {
   SPDLOG_INFO("Obtained DNS server address. Connecting to {}:{}",
       config_.server_ip.ToString(), config_.server_port);
 
+  if (!dns_ipv4_.IsEmpty() && !dns_ipv6_.IsEmpty()) {
+    return {dns_ipv4_, dns_ipv6_};
+  }
+
   const std::string ip = config_.server_ip.ToString();
   ApiClient cli(ip, config_.server_port, config_.sni,
       config_.expected_md5_fingerprint, config_.censorship_strategy);
 
-  const auto resp = cli.Get(common::api::kApiDnsUrl);
-  if (resp.code == 200) {
-    try {
-      const auto msg = resp.Json();
-      if (!msg.contains("dns")) {
-        SPDLOG_ERROR(
-            "Error: dns not found in the response. Check your connection");
-      } else {
-        const std::string dns_ipv4 = msg["dns"];
-        const std::string dns_ipv6 =
-            (msg.contains("dns_ipv6") ? msg["dns_ipv6"]
-                                      : FPTN_SERVER_DEFAULT_ADDRESS_IP6);
-        return {IPv4Address(dns_ipv4), IPv6Address(dns_ipv6)};
-      }
-    } catch (const nlohmann::json::parse_error& e) {
-      latest_error_ = e.what();
-      SPDLOG_ERROR("Error parsing JSON response: {}", e.what());
-    } catch (const std::exception& ex) {
-      latest_error_ = ex.what();
-      SPDLOG_ERROR("Exception: {}", ex.what());
+  constexpr int kMaxRetries = 3;
+  for (int attempt = 0; attempt < kMaxRetries; ++attempt) {
+    if (attempt > 0) {
+      SPDLOG_WARN("GetDns retry attempt {}/{}", attempt, kMaxRetries);
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
-  } else {
-    latest_error_ = resp.errmsg;
-    SPDLOG_ERROR(
-        "Error: Request failed code: {} msg: {}", resp.code, resp.errmsg);
+    const auto resp = cli.Get(common::api::kApiDnsUrl);
+    if (resp.code == 200) {
+      try {
+        const auto msg = resp.Json();
+        if (!msg.contains("dns")) {
+          SPDLOG_ERROR(
+              "Error: dns not found in the response. Check your connection");
+        } else {
+          const std::string dns_ipv4 = msg["dns"];
+          const std::string dns_ipv6 =
+              (msg.contains("dns_ipv6") ? msg["dns_ipv6"]
+                                        : FPTN_SERVER_DEFAULT_ADDRESS_IP6);
+          dns_ipv4_ = IPv4Address(dns_ipv4);
+          dns_ipv6_ = IPv6Address(dns_ipv6);
+          return {dns_ipv4_, dns_ipv6_};
+        }
+      } catch (const nlohmann::json::parse_error& e) {
+        latest_error_ = e.what();
+        SPDLOG_ERROR("Error parsing JSON response: {}", e.what());
+      } catch (const std::exception& ex) {
+        latest_error_ = ex.what();
+        SPDLOG_ERROR("Exception: {}", ex.what());
+      }
+    } else {
+      latest_error_ = resp.errmsg;
+      SPDLOG_ERROR(
+          "Error: Request failed code: {} msg: {}", resp.code, resp.errmsg);
+    }
   }
-  return {IPv4Address(), IPv6Address()};
+  return {dns_ipv4_, dns_ipv6_};
 }
 
 void Client::SetRecvIPPacketCallback(

--- a/src/fptn-client/vpn/http/client.h
+++ b/src/fptn-client/vpn/http/client.h
@@ -36,7 +36,7 @@ class Client final {
   ~Client();
   bool Login(const std::string& username,
       const std::string& password,
-      int timeout_sec = 15);
+      int timeout_sec = 5);
   std::pair<IPv4Address, IPv6Address> GetDns();
   bool Start();
   bool Stop();
@@ -51,7 +51,7 @@ class Client final {
   void Run();
 
  private:
-  const int kMaxReconnectionAttempts_ = 15;
+  const int kMaxReconnectionAttempts_ = 35;
 
   std::thread th_;
   mutable std::mutex mutex_;
@@ -63,6 +63,10 @@ class Client final {
   fptn::protocol::https::WebsocketClientSPtr ws_;
 
   fptn::protocol::https::WebsocketClient::Config config_;
+
+
+  IPv4Address dns_ipv4_;
+  IPv6Address dns_ipv6_;
 };
 
 using ClientPtr = std::unique_ptr<Client>;

--- a/src/fptn-client/vpn/vpn_manager.cpp
+++ b/src/fptn-client/vpn/vpn_manager.cpp
@@ -6,9 +6,11 @@ Distributed under the MIT License (https://opensource.org/licenses/MIT)
 
 #include "vpn/vpn_manager.h"
 
+#include <chrono>
 #include <functional>
 #include <memory>
 #include <string>
+#include <thread>
 #include <utility>
 
 #include <spdlog/spdlog.h>  // NOLINT(build/include_order)
@@ -26,7 +28,8 @@ bool VpnManager::IsStarted() {
 
   // const std::unique_lock<std::mutex> lock(mutex_);  // mutex
 
-  return running_ && config_.http_client && config_.http_client->IsStarted();
+  return running_ && config_.http_client &&
+         config_.http_client->IsStarted() && tun_alive_;
 }
 
 bool VpnManager::Start() {
@@ -79,6 +82,7 @@ bool VpnManager::Stop() {
     }
 
     running_ = false;
+    tun_alive_ = false;
   }
 
   ws_queue_cv_.notify_all();
@@ -240,17 +244,50 @@ void VpnManager::HandleOnIPAssignedCallback(
           config_.route_manager->Clean();
         }
 
+        // (Re)open the TUN device. After Stop() the OS adapter from the
+        // previous connection (Wintun on Windows, utun on macOS) may not be
+        // released yet, so the first Start() can fail; retry a few times with a
+        // short delay to win that race.
+        bool tun_opened = false;
         if (config_.virtual_net_interface) {
-          config_.virtual_net_interface->Start(
-              fptn::common::network::TunInterface::Config{.ipv4_addr = ip_v4,
-                  .ipv4_netmask = 32,
-                  .ipv6_addr = ip_v6,
-                  .ipv6_netmask = 126});
+          constexpr int kMaxTunOpenAttempts = 5;
+          constexpr auto kTunOpenRetryDelay = std::chrono::milliseconds(500);
+          for (int attempt = 1;
+              running_ && !tun_opened && attempt <= kMaxTunOpenAttempts;
+              ++attempt) {
+            tun_opened = config_.virtual_net_interface->Start(
+                fptn::common::network::TunInterface::Config{.ipv4_addr = ip_v4,
+                    .ipv4_netmask = 32,
+                    .ipv6_addr = ip_v6,
+                    .ipv6_netmask = 126});
+            if (!tun_opened) {
+              SPDLOG_WARN(
+                  "Failed to open TUN device on (re)connect (attempt {}/{}), "
+                  "retrying in {} ms",
+                  attempt, kMaxTunOpenAttempts, kTunOpenRetryDelay.count());
+              std::this_thread::sleep_for(kTunOpenRetryDelay);
+            }
+          }
         }
+
+        if (!tun_opened) {
+          // Do NOT apply routes over a TUN that never opened: that is exactly
+          // what produced the "green icon but no traffic" zombie. Leave
+          // tun_alive_ = false so IsStarted() reports the connection as down,
+          // letting the client tear it down and reconnect instead of silently
+          // black-holing all traffic.
+          SPDLOG_ERROR(
+              "Could not open TUN device after IP assignment; skipping route "
+              "setup and marking the connection as down so it can recover");
+          tun_alive_ = false;
+          return;
+        }
+
         if (config_.route_manager) {
           config_.route_manager->Apply(
               config_.virtual_net_interface->Name(), ip_v4, ip_v6);
         }
+        tun_alive_ = true;
       });
 
   const std::unique_lock<std::mutex> lock(mutex_);  // mutex

--- a/src/fptn-client/vpn/vpn_manager.cpp
+++ b/src/fptn-client/vpn/vpn_manager.cpp
@@ -28,8 +28,8 @@ bool VpnManager::IsStarted() {
 
   // const std::unique_lock<std::mutex> lock(mutex_);  // mutex
 
-  return running_ && config_.http_client &&
-         config_.http_client->IsStarted() && tun_alive_;
+  return running_ && config_.http_client && config_.http_client->IsStarted() &&
+         tun_alive_;
 }
 
 bool VpnManager::Start() {
@@ -251,7 +251,7 @@ void VpnManager::HandleOnIPAssignedCallback(
         bool tun_opened = false;
         if (config_.virtual_net_interface) {
           constexpr int kMaxTunOpenAttempts = 5;
-          constexpr auto kTunOpenRetryDelay = std::chrono::milliseconds(500);
+          constexpr auto kTunOpenRetryDelay = std::chrono::milliseconds(100);
           for (int attempt = 1;
               running_ && !tun_opened && attempt <= kMaxTunOpenAttempts;
               ++attempt) {
@@ -268,6 +268,15 @@ void VpnManager::HandleOnIPAssignedCallback(
               std::this_thread::sleep_for(kTunOpenRetryDelay);
             }
           }
+        }
+
+        if (!tun_opened && config_.virtual_net_interface) {
+          config_.virtual_net_interface->Stop();
+          tun_opened = config_.virtual_net_interface->Start(
+              fptn::common::network::TunInterface::Config{.ipv4_addr = ip_v4,
+                  .ipv4_netmask = 32,
+                  .ipv6_addr = ip_v6,
+                  .ipv6_netmask = 126});
         }
 
         if (!tun_opened) {

--- a/src/fptn-client/vpn/vpn_manager.h
+++ b/src/fptn-client/vpn/vpn_manager.h
@@ -58,6 +58,10 @@ class VpnManager final {
  private:
   mutable std::mutex mutex_;
   std::atomic<bool> running_;
+  // True only while the TUN device is open and its routes are applied. Gates
+  // IsStarted() so a reconnect that fails to reopen the TUN is reported as
+  // disconnected instead of a "green icon but no traffic" zombie state.
+  std::atomic<bool> tun_alive_{false};
   Config config_;
 
   std::thread thread_;

--- a/src/fptn-protocol-lib/https/api_client/api_client.cpp
+++ b/src/fptn-protocol-lib/https/api_client/api_client.cpp
@@ -58,6 +58,48 @@ Distributed under the MIT License (https://opensource.org/licenses/MIT)
 
 namespace {
 
+bool IsPortOpen(const std::string& host, const int port) {
+  try {
+    boost::asio::io_context ioc;
+    boost::asio::ip::tcp::socket socket(ioc);
+    socket.open(boost::asio::ip::tcp::v4());
+
+    const auto native = socket.native_handle();
+#ifdef _WIN32
+    DWORD timeout_ms = 700;
+    ::setsockopt(native, SOL_SOCKET, SO_SNDTIMEO,
+        reinterpret_cast<const char*>(&timeout_ms), sizeof(timeout_ms));
+#else
+    timeval tv{};
+    tv.tv_sec = 0;
+    tv.tv_usec = 700000;
+    ::setsockopt(native, SOL_SOCKET, SO_SNDTIMEO,
+        reinterpret_cast<const char*>(&tv), sizeof(tv));
+#endif
+
+    boost::asio::ip::tcp::endpoint endpoint;
+    boost::system::error_code addr_ec;
+    const auto addr = boost::asio::ip::make_address(host, addr_ec);
+    if (!addr_ec) {
+      endpoint = boost::asio::ip::tcp::endpoint(
+          addr, static_cast<boost::asio::ip::port_type>(port));
+    } else {
+      boost::asio::ip::tcp::resolver resolver(ioc);
+      const auto results = resolver.resolve(host, std::to_string(port));
+      endpoint = *results.begin();
+    }
+
+    boost::system::error_code ec;
+    socket.connect(endpoint, ec);
+    if (socket.is_open()) {
+      socket.close();
+    }
+    return !ec;
+  } catch (...) {
+    return false;
+  }
+}
+
 std::string DecompressGzip(const std::string& compressed) {
   constexpr std::size_t kChunkSize = 4096;
 
@@ -279,9 +321,13 @@ Response ApiClient::Get(const std::string& handle, int timeout) const {
   // NOLINTNEXTLINE(bugprone-exception-escape)
   return ExecuteWithTimeout<Response>(
       // NOLINTNEXTLINE(bugprone-exception-escape)
-      [this, handle, timeout]() {
-        const ApiClient cloned_client = Clone();
-        return cloned_client.GetImpl(handle, timeout);
+      [self = *this, handle, timeout]() {
+        if (!IsPortOpen(self.host_, self.port_)) {
+          SPDLOG_ERROR("GET [{}] - port {}:{} is not reachable", handle,
+              self.host_, self.port_);
+          return Response{"", 609, "Port not reachable"};
+        }
+        return self.GetImpl(handle, timeout);
       },
       timeout, "GET", handle, host_, Response{"", 608, "Operation timeout"});
 }
@@ -293,9 +339,13 @@ Response ApiClient::Post(const std::string& handle,
   // NOLINTNEXTLINE(bugprone-exception-escape)
   return ExecuteWithTimeout<Response>(
       // NOLINTNEXTLINE(bugprone-exception-escape)
-      [this, handle, request, content_type, timeout]() {
-        const ApiClient cloned_client = Clone();
-        return cloned_client.PostImpl(handle, request, content_type, timeout);
+      [self = *this, handle, request, content_type, timeout]() {
+        if (!IsPortOpen(self.host_, self.port_)) {
+          SPDLOG_ERROR("POST [{}] - port {}:{} is not reachable", handle,
+              self.host_, self.port_);
+          return Response{"", 609, "Port not reachable"};
+        }
+        return self.PostImpl(handle, request, content_type, timeout);
       },
       timeout, "POST", handle, host_, Response{"", 608, "Operation timeout"});
 }
@@ -304,9 +354,13 @@ bool ApiClient::TestHandshake(int timeout) const {
   // NOLINTNEXTLINE(bugprone-exception-escape)
   return ExecuteWithTimeout<bool>(
       // NOLINTNEXTLINE(bugprone-exception-escape)
-      [this, timeout]() {
-        const ApiClient cloned_client = Clone();
-        return cloned_client.TestHandshakeImpl(timeout);
+      [self = *this, timeout]() {
+        if (!IsPortOpen(self.host_, self.port_)) {
+          SPDLOG_ERROR("TestHandshake - port {}:{} is not reachable",
+              self.host_, self.port_);
+          return false;
+        }
+        return self.TestHandshakeImpl(timeout);
       },
       timeout, "TestHandshake", "", host_, false);
 }

--- a/src/fptn-protocol-lib/https/api_client/api_client.h
+++ b/src/fptn-protocol-lib/https/api_client/api_client.h
@@ -62,12 +62,12 @@ class ApiClient {
       std::string md5_fingerprint,
       CensorshipStrategy censorship_strategy);
 
-  Response Get(const std::string& handle, int timeout = 15) const;
+  Response Get(const std::string& handle, int timeout = 5) const;
   Response Post(const std::string& handle,
       const std::string& request,
       const std::string& content_type = "application/json",
-      int timeout = 15) const;
-  bool TestHandshake(int timeout = 10) const;
+      int timeout = 5) const;
+  bool TestHandshake(int timeout = 5) const;
 
  protected:
   ApiClient Clone() const;


### PR DESCRIPTION
On reconnect the server assigns a new client IP, which makes VpnManager::HandleOnIPAssignedCallback rebuild the tunnel: Stop() the TUN, Clean() routes, Start() the TUN, Apply() routes. The result of Start() was ignored, so when the TUN failed to reopen -- on Windows the Wintun adapter from the previous connection is often not released yet -- routes were applied over a dead device and all traffic black-holed. IsStarted() only checked the WebSocket, so the tray icon stayed green: "connected" but nothing works until a manual reconnect (which releases the adapter first).

- Retry the TUN open a few times with a short delay to win the adapter release race.
- If it still fails, skip route setup and leave the connection marked down so it tears down and reconnects instead of black-holing traffic.
- Gate IsStarted() on a new tun_alive_ flag so a dead tunnel is reported as disconnected, never a green zombie.

Reproduced from a Windows 0.4.0 GUI log: the 06:00 reconnect reopened the WebSocket, logged "Failed to open TUN device", applied routes anyway, and reported "Routing setup completed successfully" -> green icon, no traffic.